### PR TITLE
Swap out placeholder API method.

### DIFF
--- a/src/store/modules/bitcoin.js
+++ b/src/store/modules/bitcoin.js
@@ -261,15 +261,9 @@ const actions = {
   },
 
   async getRpcInfo({ commit }) {
-    // const rpcInfo = await API.get(
-    //   `${process.env.VUE_APP_MANAGER_API_URL}/v1/system/bitcoin-rpc-info`
-    // );
-    const rpcInfo = {
-      "rpcuser": "umbrelrpcuser",
-      "rpcpassword": "umbrelrpcpassword",
-      "address": "onionsmakemecrybutthatsnotthepointofthishiddenserviceaddress.onion:8332",
-      "connectionString": "btcstandup://umbrelrpc:testing123456@onionsmakemecry.onion:8332/?label=Mayank's%20Umbrel"
-    }
+    const rpcInfo = await API.get(
+      `${process.env.VUE_APP_MANAGER_API_URL}/v1/system/bitcoin-rpc-connection-details`
+    );
 
     if (rpcInfo) {
       commit("setRpcInfo", rpcInfo);


### PR DESCRIPTION
Swap out placeholder API method with the real one from https://github.com/getumbrel/umbrel-manager/pull/51.